### PR TITLE
Rebuild recipe with grayskull

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - cmake >=3.13
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - pip
     - python
@@ -41,7 +42,7 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/vowpalwabbit/
+  home: https://github.com/VowpalWabbit/vowpal_wabbit
   summary: Vowpal Wabbit Python package
   license: BSD-3-Clause
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,55 +1,53 @@
 {% set name = "vowpalwabbit" %}
-{% set version = "8.7.0" %}
+{% set version = "8.8.1" %}
+
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.post1.tar.gz
-  sha256: de9529660858b380127b2bea335b41a29e8f264551315042300022eb4e6524ea
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 46bddb560759b8d7df5b2b1cf66340102d71d74f83671d48bb572635c90bdc9d
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install -vv ."
-  skip: True  # [not linux]
+  skip: true  # [win]
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
-    - {{ compiler('cxx') }}
     - cmake >=3.13
+    - {{ compiler('c') }}
   host:
-    - py-boost
     - pip
     - python
+    - boost
+    - boost-cpp
+    - tox
+    - zlib
   run:
-    - py-boost
     - python
+    - boost
+    - boost-cpp
+    - zlib
 
 test:
   imports:
-    - {{ name }}
-  requires:
-    - numpy
-    - pandas
-    - pytest
-    - scipy
-    - scikit-learn
-  source_files:
-    - python/tests
+    - vowpalwabbit
   commands:
-    - py.test python/tests
+    - pip check
+  requires:
+    - pip
 
 about:
-  home: https://github.com/VowpalWabbit/vowpal_wabbit
+  home: https://pypi.org/project/vowpalwabbit/
+  summary: Vowpal Wabbit Python package
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
-  summary: Fast online machine learning library
-  doc_url: https://github.com/VowpalWabbit/vowpal_wabbit/wiki
-  dev_url: https://github.com/VowpalWabbit/vowpal_wabbit
 
 extra:
   recipe-maintainers:
     - gramhagen
     - peterychang
+    - xhochy


### PR DESCRIPTION
The autotick bot cannot deal with the recipe in its current shape so I regenerated the recipe with `grayskull`, added the necessary C dependencies and enabled the OSX build.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
